### PR TITLE
Set package.json license to MPL-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "firefox"
   ],
   "author": "meandave",
-  "license": "MPL",
+  "license": "MPL-2.0",
   "bugs": {
     "url": "https://github.com/mozilla/node-basket/issues"
   }


### PR DESCRIPTION
I think newer versions of npm will complain that "MPL" isn't a valid SPDX license.